### PR TITLE
Removed extra "/" displayed in multisite selector values for path based multisites.

### DIFF
--- a/src/README.txt
+++ b/src/README.txt
@@ -57,5 +57,8 @@ Nope (We're thinking about a Pro plugin for that, [vote for it here](http://www.
 
 == Changelog ==
 
+= 1.0.1 =
+* Fix: Removed extra "/" displayed in multisite selector values for path based multisites.
+
 = 1.0 =
 * Initial release.

--- a/src/admin/class-options-pixie-admin.php
+++ b/src/admin/class-options-pixie-admin.php
@@ -731,7 +731,7 @@ class Options_Pixie_Admin {
 
 				foreach ( wp_get_sites( array( 'limit' => 0 ) ) as $blog ) {
 					$blog_id     = empty( $blog['blog_id'] ) ? '' : $blog['blog_id'];
-					$description = untrailingslashit( trim( $blog['domain'] ) . '/' . trim( $blog['path'] ) );
+					$description = untrailingslashit( trim( $blog['domain'] ) . trim( $blog['path'] ) );
 
 					$selected = '';
 					if ( $current_blog_id == $blog_id ) {

--- a/src/includes/class-options-pixie.php
+++ b/src/includes/class-options-pixie.php
@@ -69,7 +69,7 @@ class Options_Pixie {
 	public function __construct() {
 
 		$this->options_pixie = 'options-pixie';
-		$this->version       = '1.0';
+		$this->version       = '1.0.1-dev';
 
 		$this->load_dependencies();
 		$this->set_locale();

--- a/src/options-pixie.php
+++ b/src/options-pixie.php
@@ -9,7 +9,7 @@
  * Plugin Name:       Options Pixie
  * Plugin URI:        http://www.bytepixie.com/options-pixie/
  * Description:       List, filter, sort and view options records, even serialized and base64 encoded values.
- * Version:           1.0
+ * Version:           1.0.1-dev
  * Author:            Byte Pixie
  * Author URI:        http://www.bytepixie.com/
  * License:           GPL-2.0+


### PR DESCRIPTION
Resolves #6.
